### PR TITLE
implement RAPTOR minus transfers

### DIFF
--- a/pkg/raptor/build.go
+++ b/pkg/raptor/build.go
@@ -268,7 +268,7 @@ func groupRouteSegments(
 		for stopIdx, stopId := range route.stopSequence {
 			routeSegmentsByStop[cursor[stopId]] = RouteSegment{
 				RouteId:   types.RouteID(routeId),
-				StopIndex: uint32(stopIdx),
+				StopIndex: StopIndex(stopIdx),
 			}
 			cursor[stopId]++
 		}

--- a/pkg/raptor/route.go
+++ b/pkg/raptor/route.go
@@ -1,59 +1,90 @@
 package raptor
 
-import "router/pkg/types"
+import (
+	"router/pkg/types"
+	"slices"
+)
 
-type RouteLeg struct {
-	routeId      types.RouteID
-	tripIdx      uint32
-	startStopIdx uint32
-	endStopIdx   uint32
+type Label struct {
+	RouteId       types.RouteID
+	TripIdx       uint32
+	BoardStopId   types.StopID
+	BoardStopIdx  StopIndex
+	AlightStopIdx StopIndex
 }
 
-type Journey struct {
-	arrivalTime types.Timestamp
-	legs        []RouteLeg
-}
+const MAX_ROUNDS = 10
 
-func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime types.Timestamp) {
-	currentBest := make([]Journey, rt.NumStops())
+func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime types.Timestamp) []Label {
+	parent := make([]Label, rt.NumStops())
 
-	var round = 0
+	best := make([]types.Timestamp, rt.NumStops())
+	for i := range best {
+		best[i] = types.INFINITY
+	}
 
-	var stopsToConsider = []types.StopID{start}
+	best[start] = startTime
 
-	for {
-		var nextStopsToConsider []types.StopID
+	var prevBest []types.Timestamp
 
-		for _, stopId := range stopsToConsider {
-			currentJourney := currentBest[stopId]
-			routesForStop := rt.RoutesForStop(stopId)
+	stopsUpdated := []types.StopID{start}
 
-			for _, routeSegment := range routesForStop {
-				routeId := routeSegment.RouteId
-				startStopIdx := routeSegment.StopIndex
+	for len(stopsUpdated) > 0 {
+		prevBest = make([]types.Timestamp, rt.NumStops())
+		copy(prevBest, best)
 
-				stopsForRoute := rt.StopsForRoute(routeId)
-				for tripIdx := range rt.NumTripsInRoute[routeId] {
-					stopEvents := rt.StopEventsForTrip(routeId, tripIdx)
-					if stopEvents[startStopIdx].DepartureTime > currentJourney.arrivalTime {
-						for endStopIdx := startStopIdx; endStopIdx < uint32(len(stopEvents)); endStopIdx++ {
-							stopEvent := stopEvents[endStopIdx]
+		routeEarliestStop := make(map[types.RouteID]StopIndex)
 
-							stopId := stopsForRoute[endStopIdx]
-							if stopEvent.ArrivalTime < currentBest[stopId].arrivalTime {
-								currentBest[stopId] = Journey{
-									arrivalTime: stopEvent.ArrivalTime,
-									legs: append(
-										currentJourney.legs,
-										RouteLeg{
-											routeId:      routeId,
-											tripIdx:      tripIdx,
-											startStopIdx: startStopIdx,
-											endStopIdx:   endStopIdx,
-										},
-									)}
-								nextStopsToConsider = append(nextStopsToConsider, stopId)
-							}
+		for _, stopId := range stopsUpdated {
+			for _, segment := range rt.RoutesForStop(stopId) {
+				if existing, ok := routeEarliestStop[segment.RouteId]; !ok || segment.StopIndex < existing {
+					routeEarliestStop[segment.RouteId] = segment.StopIndex
+				}
+			}
+		}
+
+		var nextStopsUpdated []types.StopID
+
+		for routeId, firstStopIdx := range routeEarliestStop {
+			stopsForRoute := rt.StopsForRoute(routeId)
+
+			currentTripIdx := -1
+			boardStopId := types.StopID(0)
+			boardStopIdx := uint32(0)
+
+			for currStopIdx := int(firstStopIdx); currStopIdx < len(stopsForRoute); currStopIdx++ {
+				currStopId := stopsForRoute[currStopIdx]
+
+				if currentTripIdx >= 0 {
+					events := rt.StopEventsForTrip(routeId, uint32(currentTripIdx))
+					if events[currStopIdx].ArrivalTime < best[currStopId] {
+						best[currStopId] = events[currStopIdx].ArrivalTime
+						parent[currStopId] = Label{
+							RouteId:       routeId,
+							TripIdx:       uint32(currentTripIdx),
+							BoardStopId:   boardStopId,
+							BoardStopIdx:  StopIndex(boardStopIdx),
+							AlightStopIdx: StopIndex(currStopIdx),
+						}
+						nextStopsUpdated = append(nextStopsUpdated, currStopId)
+					}
+				}
+
+				prevArrival := prevBest[currStopId]
+				if prevArrival == types.INFINITY {
+					continue
+				}
+
+				earliestBoard := prevArrival + types.Timestamp(rt.MinTransferTime[currStopId])
+
+				numTrips := rt.NumTripsInRoute[routeId]
+				for potentialTripIdx := range numTrips {
+					stopEvents := rt.StopEventsForTrip(routeId, potentialTripIdx)
+					if stopEvents[currStopIdx].DepartureTime >= earliestBoard {
+						if currentTripIdx < 0 || potentialTripIdx < uint32(currentTripIdx) {
+							currentTripIdx = int(potentialTripIdx)
+							boardStopId = currStopId
+							boardStopIdx = uint32(currStopIdx)
 						}
 
 						break
@@ -62,7 +93,22 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 			}
 		}
 
-		stopsToConsider = nextStopsToConsider
-		round++
+		stopsUpdated = nextStopsUpdated
 	}
+
+	if best[end] == types.INFINITY {
+		return nil
+	}
+
+	var legs []Label
+
+	for stop := end; stop != start; {
+		label := parent[stop]
+		legs = append(legs, label)
+		stop = label.BoardStopId
+	}
+
+	slices.Reverse(legs)
+
+	return legs
 }

--- a/pkg/raptor/route.go
+++ b/pkg/raptor/route.go
@@ -78,7 +78,7 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 
 				if currentTripIdx >= 0 {
 					arrivalTime := rt.StopEventsForTrip(routeId, uint32(currentTripIdx))[currStopIdx].ArrivalTime
-					if arrivalTime < rounds[round][currStopId] {
+					if arrivalTime < rounds[round][currStopId] && arrivalTime < best[end] {
 						rounds[round][currStopId] = arrivalTime
 
 						parents[round][currStopId] = Label{
@@ -128,10 +128,6 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 	var pareto []Journey
 
 	for round := 1; round <= MAX_ROUNDS; round++ {
-		if round == 0 {
-			continue
-		}
-
 		if rounds[round][end] < rounds[round-1][end] {
 			pareto = append(pareto, Journey{
 				NumLegs:     round,

--- a/pkg/raptor/route.go
+++ b/pkg/raptor/route.go
@@ -1,0 +1,68 @@
+package raptor
+
+import "router/pkg/types"
+
+type RouteLeg struct {
+	routeId      types.RouteID
+	tripIdx      uint32
+	startStopIdx uint32
+	endStopIdx   uint32
+}
+
+type Journey struct {
+	arrivalTime types.Timestamp
+	legs        []RouteLeg
+}
+
+func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime types.Timestamp) {
+	currentBest := make([]Journey, rt.NumStops())
+
+	var round = 0
+
+	var stopsToConsider = []types.StopID{start}
+
+	for {
+		var nextStopsToConsider []types.StopID
+
+		for _, stopId := range stopsToConsider {
+			currentJourney := currentBest[stopId]
+			routesForStop := rt.RoutesForStop(stopId)
+
+			for _, routeSegment := range routesForStop {
+				routeId := routeSegment.RouteId
+				startStopIdx := routeSegment.StopIndex
+
+				stopsForRoute := rt.StopsForRoute(routeId)
+				for tripIdx := range rt.NumTripsInRoute[routeId] {
+					stopEvents := rt.StopEventsForTrip(routeId, tripIdx)
+					if stopEvents[startStopIdx].DepartureTime > currentJourney.arrivalTime {
+						for endStopIdx := startStopIdx; endStopIdx < uint32(len(stopEvents)); endStopIdx++ {
+							stopEvent := stopEvents[endStopIdx]
+
+							stopId := stopsForRoute[endStopIdx]
+							if stopEvent.ArrivalTime < currentBest[stopId].arrivalTime {
+								currentBest[stopId] = Journey{
+									arrivalTime: stopEvent.ArrivalTime,
+									legs: append(
+										currentJourney.legs,
+										RouteLeg{
+											routeId:      routeId,
+											tripIdx:      tripIdx,
+											startStopIdx: startStopIdx,
+											endStopIdx:   endStopIdx,
+										},
+									)}
+								nextStopsToConsider = append(nextStopsToConsider, stopId)
+							}
+						}
+
+						break
+					}
+				}
+			}
+		}
+
+		stopsToConsider = nextStopsToConsider
+		round++
+	}
+}

--- a/pkg/raptor/route.go
+++ b/pkg/raptor/route.go
@@ -13,25 +13,46 @@ type Label struct {
 	AlightStopIdx StopIndex
 }
 
+type Journey struct {
+	NumLegs     int
+	ArrivalTime types.Timestamp
+	Legs        []Label
+}
+
 const MAX_ROUNDS = 10
 
-func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime types.Timestamp) []Label {
-	parent := make([]Label, rt.NumStops())
+func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime types.Timestamp) []Journey {
+	numStops := rt.NumStops()
 
-	best := make([]types.Timestamp, rt.NumStops())
+	parents := make([][]Label, MAX_ROUNDS+1)
+
+	rounds := make([][]types.Timestamp, MAX_ROUNDS+1)
+	for k := range rounds {
+		parents[k] = make([]Label, numStops)
+
+		rounds[k] = make([]types.Timestamp, numStops)
+		for s := range rounds[k] {
+			rounds[k][s] = types.INFINITY
+		}
+	}
+
+	rounds[0][start] = startTime
+
+	best := make([]types.Timestamp, numStops)
 	for i := range best {
 		best[i] = types.INFINITY
 	}
 
 	best[start] = startTime
 
-	var prevBest []types.Timestamp
-
 	stopsUpdated := []types.StopID{start}
 
-	for len(stopsUpdated) > 0 {
-		prevBest = make([]types.Timestamp, rt.NumStops())
-		copy(prevBest, best)
+	for round := range MAX_ROUNDS {
+		if len(stopsUpdated) == 0 {
+			break
+		}
+
+		copy(rounds[round], rounds[round-1])
 
 		routeEarliestStop := make(map[types.RouteID]StopIndex)
 
@@ -56,21 +77,25 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 				currStopId := stopsForRoute[currStopIdx]
 
 				if currentTripIdx >= 0 {
-					events := rt.StopEventsForTrip(routeId, uint32(currentTripIdx))
-					if events[currStopIdx].ArrivalTime < best[currStopId] {
-						best[currStopId] = events[currStopIdx].ArrivalTime
-						parent[currStopId] = Label{
+					arrivalTime := rt.StopEventsForTrip(routeId, uint32(currentTripIdx))[currStopIdx].ArrivalTime
+					if arrivalTime < rounds[round][currStopId] {
+						rounds[round][currStopId] = arrivalTime
+
+						parents[round][currStopId] = Label{
 							RouteId:       routeId,
 							TripIdx:       uint32(currentTripIdx),
 							BoardStopId:   boardStopId,
 							BoardStopIdx:  StopIndex(boardStopIdx),
 							AlightStopIdx: StopIndex(currStopIdx),
 						}
-						nextStopsUpdated = append(nextStopsUpdated, currStopId)
+						if arrivalTime < best[currStopId] {
+							best[currStopId] = arrivalTime
+							nextStopsUpdated = append(nextStopsUpdated, currStopId)
+						}
 					}
 				}
 
-				prevArrival := prevBest[currStopId]
+				prevArrival := rounds[round-1][currStopId]
 				if prevArrival == types.INFINITY {
 					continue
 				}
@@ -100,12 +125,34 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 		return nil
 	}
 
+	var pareto []Journey
+
+	for round := range MAX_ROUNDS {
+		if round == 0 {
+			continue
+		}
+
+		if rounds[round][end] > rounds[round-1][end] {
+			pareto = append(pareto, Journey{
+				NumLegs:     round,
+				ArrivalTime: rounds[round][end],
+				Legs:        reconstructLegs(start, end, round, parents),
+			})
+		}
+	}
+
+	return pareto
+}
+
+func reconstructLegs(start, end types.StopID, round int, parents [][]Label) []Label {
 	var legs []Label
 
-	for stop := end; stop != start; {
-		label := parent[stop]
+	stop := end
+	for round > 0 && stop != start {
+		label := parents[round][stop]
 		legs = append(legs, label)
 		stop = label.BoardStopId
+		round--
 	}
 
 	slices.Reverse(legs)

--- a/pkg/raptor/route.go
+++ b/pkg/raptor/route.go
@@ -47,7 +47,7 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 
 	stopsUpdated := []types.StopID{start}
 
-	for round := range MAX_ROUNDS {
+	for round := 1; round <= MAX_ROUNDS; round++ {
 		if len(stopsUpdated) == 0 {
 			break
 		}
@@ -127,12 +127,12 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 
 	var pareto []Journey
 
-	for round := range MAX_ROUNDS {
+	for round := 1; round <= MAX_ROUNDS; round++ {
 		if round == 0 {
 			continue
 		}
 
-		if rounds[round][end] > rounds[round-1][end] {
+		if rounds[round][end] < rounds[round-1][end] {
 			pareto = append(pareto, Journey{
 				NumLegs:     round,
 				ArrivalTime: rounds[round][end],

--- a/pkg/raptor/route.go
+++ b/pkg/raptor/route.go
@@ -24,8 +24,10 @@ const MAX_ROUNDS = 10
 func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime types.Timestamp) []Journey {
 	numStops := rt.NumStops()
 
+	// parents[k][s]: the label preceding rounds[k][s] for route reconstruction
 	parents := make([][]Label, MAX_ROUNDS+1)
 
+	// rounds[k][s]: best arrival at stop s with k or fewer trasnit legs
 	rounds := make([][]types.Timestamp, MAX_ROUNDS+1)
 	for k := range rounds {
 		parents[k] = make([]Label, numStops)
@@ -38,6 +40,7 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 
 	rounds[0][start] = startTime
 
+	// best[s]: the best arrival time for stop s over all rounds for cross-round pruning
 	best := make([]types.Timestamp, numStops)
 	for i := range best {
 		best[i] = types.INFINITY
@@ -45,15 +48,21 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 
 	best[start] = startTime
 
+	// we store which stops were updated in round k-1 so we can check if
+	// they enable new connections in round k
 	stopsUpdated := []types.StopID{start}
 
 	for round := 1; round <= MAX_ROUNDS; round++ {
+		// if no stops were updated last round, we are done
 		if len(stopsUpdated) == 0 {
 			break
 		}
 
+		// we start with the arrival times from the previous round
 		copy(rounds[round], rounds[round-1])
 
+		// for each route serving an updated stop, we remember the earliest
+		// updated stop index in that route so we can board ASAP
 		routeEarliestStop := make(map[types.RouteID]StopIndex)
 
 		for _, stopId := range stopsUpdated {
@@ -64,11 +73,16 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 			}
 		}
 
+		// the stops updated in this round to provide the updated set for the next round
 		var nextStopsUpdated []types.StopID
 
+		// traverse each route left to right
 		for routeId, firstStopIdx := range routeEarliestStop {
 			stopsForRoute := rt.StopsForRoute(routeId)
 
+			// the current trip we're on for the route
+			// we might discover we can board an earlier trip
+			// and then we will switch to that
 			currentTripIdx := -1
 			boardStopId := types.StopID(0)
 			boardStopIdx := uint32(0)
@@ -76,6 +90,7 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 			for currStopIdx := int(firstStopIdx); currStopIdx < len(stopsForRoute); currStopIdx++ {
 				currStopId := stopsForRoute[currStopIdx]
 
+				// arrival: if we're on a trip, check if we can get to any stop earlier than we could before
 				if currentTripIdx >= 0 {
 					arrivalTime := rt.StopEventsForTrip(routeId, uint32(currentTripIdx))[currStopIdx].ArrivalTime
 					if arrivalTime < rounds[round][currStopId] && arrivalTime < best[end] {
@@ -88,6 +103,8 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 							BoardStopIdx:  StopIndex(boardStopIdx),
 							AlightStopIdx: StopIndex(currStopIdx),
 						}
+						// we only need tp mark for next round if the is the best arrival time
+						// over all rounds
 						if arrivalTime < best[currStopId] {
 							best[currStopId] = arrivalTime
 							nextStopsUpdated = append(nextStopsUpdated, currStopId)
@@ -95,13 +112,17 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 					}
 				}
 
+				// if we haven't ever arrived at this stop before
+				// we don't need to consider boarding a new trip here
 				prevArrival := rounds[round-1][currStopId]
 				if prevArrival == types.INFINITY {
 					continue
 				}
 
+				// boarding: check if we can catch an earlier trip by boarding here
 				earliestBoard := prevArrival + types.Timestamp(rt.MinTransferTime[currStopId])
 
+				// check each trip for the first one departing after our arrival
 				numTrips := rt.NumTripsInRoute[routeId]
 				for potentialTripIdx := range numTrips {
 					stopEvents := rt.StopEventsForTrip(routeId, potentialTripIdx)
@@ -118,15 +139,20 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 			}
 		}
 
+		// TODO: use precomputed street network transfers to update
+		// the best[s] and rounds[k][s] entries and add to nextStopsUpdated
+
 		stopsUpdated = nextStopsUpdated
 	}
 
+	// if we never got to the destination, fail
 	if best[end] == types.INFINITY {
 		return nil
 	}
 
 	var pareto []Journey
 
+	// reconstruct pareto frontier from parents
 	for round := 1; round <= MAX_ROUNDS; round++ {
 		if rounds[round][end] < rounds[round-1][end] {
 			pareto = append(pareto, Journey{

--- a/pkg/raptor/route.go
+++ b/pkg/raptor/route.go
@@ -27,7 +27,7 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 	// parents[k][s]: the label preceding rounds[k][s] for route reconstruction
 	parents := make([][]Label, MAX_ROUNDS+1)
 
-	// rounds[k][s]: best arrival at stop s with k or fewer trasnit legs
+	// rounds[k][s]: best arrival at stop s with k or fewer transit legs
 	rounds := make([][]types.Timestamp, MAX_ROUNDS+1)
 	for k := range rounds {
 		parents[k] = make([]Label, numStops)
@@ -67,7 +67,8 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 
 		for _, stopId := range stopsUpdated {
 			for _, segment := range rt.RoutesForStop(stopId) {
-				if existing, ok := routeEarliestStop[segment.RouteId]; !ok || segment.StopIndex < existing {
+				existing, ok := routeEarliestStop[segment.RouteId]
+				if !ok || segment.StopIndex < existing {
 					routeEarliestStop[segment.RouteId] = segment.StopIndex
 				}
 			}
@@ -142,6 +143,7 @@ func (rt *RaptorTable) Route(start types.StopID, end types.StopID, startTime typ
 		// TODO: use precomputed street network transfers to update
 		// the best[s] and rounds[k][s] entries and add to nextStopsUpdated
 
+		// seed the next round with the updated stops for this round
 		stopsUpdated = nextStopsUpdated
 	}
 

--- a/pkg/raptor/table.go
+++ b/pkg/raptor/table.go
@@ -28,9 +28,11 @@ type StopEvent struct {
 	DepartureTime types.Timestamp
 }
 
+type StopIndex uint32
+
 type RouteSegment struct {
 	RouteId   types.RouteID
-	StopIndex uint32
+	StopIndex StopIndex
 }
 
 type RouteStopOffsets []uint32        // indexed by types.RouteID

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -4,3 +4,5 @@ type StopID uint32
 type RouteID uint32
 
 type Timestamp uint32 // seconds since midnight
+
+const INFINITY Timestamp = Timestamp(^uint32(0) / 2)


### PR DESCRIPTION
Fixes #4 

a mostly complete RAPTOR implementation but doesn't include transfers so it can only return routes that start and leave from other stops